### PR TITLE
Improve blockquote behavior for nested elements

### DIFF
--- a/packages/slate-plugins/src/__fixtures__/autoformat.fixtures.ts
+++ b/packages/slate-plugins/src/__fixtures__/autoformat.fixtures.ts
@@ -1,5 +1,6 @@
 import { Editor } from 'slate';
 import { options } from '../../../../stories/config/initialValues';
+import { toggleBlockquote } from '../elements/blockquote';
 import { insertCodeBlock } from '../elements/code-block';
 import { toggleList } from '../elements/list/transforms/toggleList';
 import { unwrapList } from '../elements/list/transforms/unwrapList';
@@ -62,6 +63,9 @@ export const autoformatRulesFixtures: AutoformatRule[] = [
     type: options.blockquote.type,
     markup: ['>'],
     preFormat,
+    format: (editor) => {
+      toggleBlockquote(editor, options);
+    },
   },
   {
     type: MARK_BOLD,

--- a/packages/slate-plugins/src/common/utils/getOnHotkeyToggleNodeType.ts
+++ b/packages/slate-plugins/src/common/utils/getOnHotkeyToggleNodeType.ts
@@ -14,11 +14,10 @@ export interface GetOnHotkeyToggleNodeTypeOptions extends HotkeyOptions {
 /**
  * Get `onKeyDown` handler to toggle node type if hotkey is pressed.
  */
-export const getOnHotkeyToggleNodeType = ({
-  type,
-  defaultType,
-  hotkey,
-}: GetOnHotkeyToggleNodeTypeOptions) => {
+export const getOnHotkeyToggleNodeType = (
+  { type, defaultType, hotkey }: GetOnHotkeyToggleNodeTypeOptions,
+  customToggleMethod: any
+) => {
   if (!hotkey) return;
 
   const hotkeys = castArray(hotkey);
@@ -27,6 +26,13 @@ export const getOnHotkeyToggleNodeType = ({
     for (const key of hotkeys) {
       if (isHotkey(key, e)) {
         e.preventDefault();
+        if (customToggleMethod) {
+          customToggleMethod(editor, {
+            activeType: type,
+            inactiveType: defaultType,
+          });
+          return;
+        }
         toggleNodeType(editor, { activeType: type, inactiveType: defaultType });
         return;
       }

--- a/packages/slate-plugins/src/common/utils/getOnHotkeyToggleNodeTypeDefault.ts
+++ b/packages/slate-plugins/src/common/utils/getOnHotkeyToggleNodeTypeDefault.ts
@@ -5,6 +5,7 @@ interface GetOnHotkeyToggleNodeTypeDefaultOptions {
   key: string;
   defaultOptions: Record<string, any>;
   options?: any;
+  customToggleMethod?: any;
 }
 
 /**
@@ -14,8 +15,9 @@ export const getOnHotkeyToggleNodeTypeDefault = ({
   key,
   defaultOptions,
   options,
+  customToggleMethod,
 }: GetOnHotkeyToggleNodeTypeDefaultOptions) => {
   const keyOptions = setDefaults(options, defaultOptions)[key];
 
-  return getOnHotkeyToggleNodeType(keyOptions);
+  return getOnHotkeyToggleNodeType(keyOptions, customToggleMethod);
 };

--- a/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
+++ b/packages/slate-plugins/src/elements/blockquote/BlockquotePlugin.ts
@@ -4,6 +4,7 @@ import { DEFAULTS_BLOCKQUOTE } from './defaults';
 import { deserializeBlockquote } from './deserializeBlockquote';
 import { renderElementBlockquote } from './renderElementBlockquote';
 import { BlockquotePluginOptions } from './types';
+import { toggleBlockquote } from './transforms/toggleBlockquote';
 
 /**
  * Enables support for block quotes, useful for
@@ -18,5 +19,6 @@ export const BlockquotePlugin = (
     key: 'blockquote',
     defaultOptions: DEFAULTS_BLOCKQUOTE,
     options,
+    customToggleMethod: toggleBlockquote
   }),
 });

--- a/packages/slate-plugins/src/elements/blockquote/components/ToolbarBlockquote.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/components/ToolbarBlockquote.tsx
@@ -8,6 +8,7 @@ import { DEFAULTS_BLOCKQUOTE } from '../defaults';
 import { toggleBlockquote } from '../transforms/toggleBlockquote';
 import { BlockquotePluginOptions } from '../types';
 
+//Custom toolbar button to connect to toggleBLockquote
 export const ToolbarBlockquote = ({
   options,
   ...props

--- a/packages/slate-plugins/src/elements/blockquote/components/ToolbarBlockquote.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/components/ToolbarBlockquote.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { useSlate } from 'slate-react';
+import { getPreventDefaultHandler } from '../../../common/utils/getPreventDefaultHandler';
+import { setDefaults } from '../../../common/utils/setDefaults';
+import { ToolbarButtonProps } from '../../../components/ToolbarButton/ToolbarButton.types';
+import { ToolbarElement } from '../../../components/ToolbarElement/ToolbarElement';
+import { DEFAULTS_BLOCKQUOTE } from '../defaults';
+import { toggleBlockquote } from '../transforms/toggleBlockquote';
+import { BlockquotePluginOptions } from '../types';
+
+export const ToolbarBlockquote = ({
+  options,
+  ...props
+}: ToolbarButtonProps & { options: BlockquotePluginOptions }) => {
+  const { blockquote } = setDefaults(options, DEFAULTS_BLOCKQUOTE);
+
+  const editor = useSlate();
+
+  return (
+    <ToolbarElement
+      type={blockquote.type}
+      onMouseDown={getPreventDefaultHandler(toggleBlockquote, editor, options)}
+      {...props}
+    />
+  );
+};

--- a/packages/slate-plugins/src/elements/blockquote/components/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/components/index.ts
@@ -1,2 +1,3 @@
 export * from './BlockquoteElement.styles';
 export * from './BlockquoteElement';
+export * from './ToolbarBlockquote'

--- a/packages/slate-plugins/src/elements/blockquote/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
+export * from './transforms';
 export * from './BlockquotePlugin';
 export * from './defaults';
 export * from './deserializeBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/transforms/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/index.ts
@@ -1,0 +1,2 @@
+export * from './toggleBlockquote';
+export * from './unwrapBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
@@ -6,6 +6,7 @@ import { DEFAULTS_BLOCKQUOTE } from '../defaults';
 import { BlockquotePluginOptions } from '../types';
 import { unwrapBlockquote } from './unwrapBlockquote';
 
+//Overwrite default blockquote behavior by using wrapNodes() instead of setNodes()
 export const toggleBlockquote = (
   editor: Editor,
   options: BlockquotePluginOptions,

--- a/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
@@ -9,7 +9,7 @@ import { unwrapBlockquote } from './unwrapBlockquote';
 //Overwrite default blockquote behavior by using wrapNodes() instead of setNodes()
 export const toggleBlockquote = (
   editor: Editor,
-  options: BlockquotePluginOptions,
+  options: BlockquotePluginOptions
 ) => {
   if (!editor.selection) return;
 

--- a/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/toggleBlockquote.ts
@@ -1,0 +1,23 @@
+import { Editor } from 'slate';
+import { someNode } from '../../../common/queries/someNode';
+import { wrapNodes } from '../../../common/transforms/wrapNodes';
+import { setDefaults } from '../../../common/utils/setDefaults';
+import { DEFAULTS_BLOCKQUOTE } from '../defaults';
+import { BlockquotePluginOptions } from '../types';
+import { unwrapBlockquote } from './unwrapBlockquote';
+
+export const toggleBlockquote = (
+  editor: Editor,
+  options: BlockquotePluginOptions,
+) => {
+  if (!editor.selection) return;
+
+  const { blockquote } = setDefaults(options, DEFAULTS_BLOCKQUOTE);
+  const isActive = someNode(editor, { match: { type: blockquote.type } });
+
+  unwrapBlockquote(editor, options);
+
+  if (!isActive) {
+    wrapNodes(editor, { type: blockquote.type, children: [] });
+  }
+};

--- a/packages/slate-plugins/src/elements/blockquote/transforms/unwrapBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/unwrapBlockquote.ts
@@ -4,6 +4,7 @@ import { setDefaults } from '../../../common/utils/setDefaults';
 import { DEFAULTS_BLOCKQUOTE } from '../defaults';
 import { BlockquotePluginOptions } from '../types';
 
+//Custom blockquote unwraping using unwrapNodes()
 export const unwrapBlockquote = (
   editor: Editor,
   options?: BlockquotePluginOptions

--- a/packages/slate-plugins/src/elements/blockquote/transforms/unwrapBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/transforms/unwrapBlockquote.ts
@@ -1,0 +1,14 @@
+import { Editor } from 'slate';
+import { unwrapNodes } from '../../../common/transforms';
+import { setDefaults } from '../../../common/utils/setDefaults';
+import { DEFAULTS_BLOCKQUOTE } from '../defaults';
+import { BlockquotePluginOptions } from '../types';
+
+export const unwrapBlockquote = (
+  editor: Editor,
+  options?: BlockquotePluginOptions
+) => {
+  const { blockquote } = setDefaults(options, DEFAULTS_BLOCKQUOTE);
+
+  unwrapNodes(editor, { match: { type: blockquote.type }, split: true });
+};

--- a/stories/config/autoformatRules.ts
+++ b/stories/config/autoformatRules.ts
@@ -1,6 +1,7 @@
 import {
   AutoformatRule,
   insertCodeBlock,
+  toggleBlockquote,
   toggleList,
   unwrapList,
 } from '@udecode/slate-plugins';
@@ -64,6 +65,9 @@ export const autoformatRules: AutoformatRule[] = [
     type: options.blockquote.type,
     markup: ['>'],
     preFormat,
+    format: (editor) => {
+      toggleBlockquote(editor, options);
+    },
   },
   {
     type: options.bold.type,

--- a/stories/examples/playground.stories.tsx
+++ b/stories/examples/playground.stories.tsx
@@ -67,6 +67,7 @@ import {
   TablePlugin,
   TodoListPlugin,
   ToolbarAlign,
+  ToolbarBlockquote,
   ToolbarCodeBlock,
   ToolbarElement,
   ToolbarImage,
@@ -306,9 +307,10 @@ export const Plugins = () => {
             typeList={options.ol.type}
             icon={<FormatListNumbered />}
           />
-          <ToolbarElement
+          <ToolbarBlockquote
             type={options.blockquote.type}
             icon={<FormatQuote />}
+            options={options}
           />
           <ToolbarCodeBlock
             type={options.code_block.type}


### PR DESCRIPTION
## Issue
Toggling blockquotes on an element or a list of elements would reset their format and create a separate blockquote for each element

## What I did
- Create a custom Transform helper function `toggleBlockquote` that depends on `wrapNodes` instead of `setNodes` to overwrite the default behavior (Which existed here `src/common/transforms/toggleNodeType.ts`) and make sure all nested elements maintain the same format

- Connect created Transform to a custom toolbar action button `ToolbarBlockquote` and remove `ToolbarElement` 

- Add custom toggle method support to hotkey events and use created Transform on hotkey press

- Add Transform as a format method when creating a blockquote using markdown

#### Before:

https://user-images.githubusercontent.com/13141632/110261621-421bf700-7fb1-11eb-9caa-2c1bacd6b1c7.mp4

#### After:

https://user-images.githubusercontent.com/13141632/110261627-447e5100-7fb1-11eb-829f-8fa668fa644b.mp4

Related docs: https://docs.slatejs.org/api/transforms

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.


<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->